### PR TITLE
Fixed minor imperfections

### DIFF
--- a/examples/generate_index_sitemap.rs
+++ b/examples/generate_index_sitemap.rs
@@ -7,15 +7,21 @@ fn main() {
         Sitemap::new(
             String::from("http://www.example.com/sitemap1.xml.gz"),
             Some(DateTime::from_utc(
-                NaiveDate::from_ymd(2004, 10, 1).and_hms(18, 23, 17),
-                FixedOffset::east(0),
+                NaiveDate::from_ymd_opt(2004, 10, 1)
+                    .unwrap()
+                    .and_hms_opt(18, 23, 17)
+                    .unwrap(),
+                FixedOffset::east_opt(0).unwrap(),
             )),
         ),
         Sitemap::new(
             String::from("http://www.example.com/sitemap2.xml.gz"),
             Some(DateTime::from_utc(
-                NaiveDate::from_ymd(2005, 1, 1).and_hms(0, 0, 0),
-                FixedOffset::east(0),
+                NaiveDate::from_ymd_opt(2005, 1, 1)
+                    .unwrap()
+                    .and_hms_opt(0, 0, 0)
+                    .unwrap(),
+                FixedOffset::east_opt(0).unwrap(),
             )),
         ),
     ];

--- a/examples/generate_news_sitemap.rs
+++ b/examples/generate_news_sitemap.rs
@@ -10,8 +10,11 @@ fn main() {
     .news(News::new(
         Publication::new(String::from("The Example Times"), String::from("en")),
         DateTime::from_utc(
-            NaiveDate::from_ymd(2008, 12, 23).and_hms(0, 0, 0),
-            FixedOffset::east(0),
+            NaiveDate::from_ymd_opt(2008, 12, 23)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+            FixedOffset::east_opt(0).unwrap(),
         ),
         String::from("Companies A, B in Merger Talks"),
     ))

--- a/examples/generate_url_sitemap.rs
+++ b/examples/generate_url_sitemap.rs
@@ -5,8 +5,11 @@ use sitemap_rs::url_set::UrlSet;
 fn main() {
     let urls: Vec<Url> = vec![Url::builder(String::from("http://www.example.com/"))
         .last_modified(DateTime::from_utc(
-            NaiveDate::from_ymd(2005, 1, 1).and_hms(0, 0, 0),
-            FixedOffset::east(0),
+            NaiveDate::from_ymd_opt(2005, 1, 1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+            FixedOffset::east_opt(0).unwrap(),
         ))
         .change_frequency(ChangeFrequency::Monthly)
         .priority(0.8)

--- a/examples/generate_video_sitemap.rs
+++ b/examples/generate_video_sitemap.rs
@@ -14,14 +14,20 @@ fn main() {
     )
     .duration(600)
     .expiration_date(DateTime::from_utc(
-        NaiveDate::from_ymd(2021, 11, 5).and_hms(11, 20, 30),
-        FixedOffset::east(8 * 3600),
+        NaiveDate::from_ymd_opt(2021, 11, 5)
+            .unwrap()
+            .and_hms_opt(11, 20, 30)
+            .unwrap(),
+        FixedOffset::east_opt(8 * 3600).unwrap(),
     ))
     .rating(4.2)
     .view_count(12345)
     .publication_date(DateTime::from_utc(
-        NaiveDate::from_ymd(2007, 11, 5).and_hms(11, 20, 30),
-        FixedOffset::east(8 * 3600),
+        NaiveDate::from_ymd_opt(2007, 11, 5)
+            .unwrap()
+            .and_hms_opt(11, 20, 30)
+            .unwrap(),
+        FixedOffset::east_opt(8 * 3600).unwrap(),
     ))
     .family_friendly(true)
     .restriction(Restriction::new(

--- a/src/sitemap_index_error.rs
+++ b/src/sitemap_index_error.rs
@@ -14,7 +14,7 @@ impl Display for SitemapIndexError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::TooManySitemaps(count) => {
-                write!(f, "must not contain more than 50,000 sitemaps: {}", count)
+                write!(f, "must not contain more than 50,000 sitemaps: {count}")
             }
         }
     }

--- a/src/url_error.rs
+++ b/src/url_error.rs
@@ -20,13 +20,13 @@ impl Display for UrlError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::PriorityTooLow(priority) => {
-                write!(f, "priority must not be below 0.0: {}", priority)
+                write!(f, "priority must not be below 0.0: {priority}")
             }
             Self::PriorityTooHigh(priority) => {
-                write!(f, "priority must not be above 1.0: {}", priority)
+                write!(f, "priority must not be above 1.0: {priority}")
             }
             Self::TooManyImages(count) => {
-                write!(f, "must not contain more tha 1,000 images: {}", count)
+                write!(f, "must not contain more tha 1,000 images: {count}")
             }
         }
     }

--- a/src/url_set.rs
+++ b/src/url_set.rs
@@ -21,7 +21,7 @@ pub struct UrlSet {
     /// A namespace extension for allowing \<video\> in the UrlSet.
     pub xmlns_video: Option<String>,
 
-    /// A namespace extension for allowing \<new\> in the UrlSet.
+    /// A namespace extension for allowing \<news\> in the UrlSet.
     pub xmlns_news: Option<String>,
 
     /// All the URLs that will become indexed.
@@ -107,7 +107,7 @@ impl UrlSet {
             urlset.add_attribute("xmlns:video", xmlns_video.as_str());
         }
 
-        // set video namespace, if it exists
+        // set news namespace, if it exists
         if let Some(xmlns_news) = self.xmlns_news {
             urlset.add_attribute("xmlns:news", xmlns_news.as_str());
         }

--- a/src/url_set_error.rs
+++ b/src/url_set_error.rs
@@ -17,10 +17,10 @@ impl Display for UrlSetError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::TooManyUrls(count) => {
-                write!(f, "must not contain more than 50,000 URLs: {}", count)
+                write!(f, "must not contain more than 50,000 URLs: {count}")
             }
             Self::TooMuchNews(count) => {
-                write!(f, "must not contains more than 1,000 news URLs: {}", count)
+                write!(f, "must not contains more than 1,000 news URLs: {count}")
             }
         }
     }

--- a/src/video_error.rs
+++ b/src/video_error.rs
@@ -34,27 +34,26 @@ impl Display for VideoError {
             Self::DescriptionTooLong(count) => {
                 write!(
                     f,
-                    "description cannot be longer than 2048 characters: {}",
-                    count
+                    "description cannot be longer than 2048 characters: {count}"
                 )
             }
             Self::DurationTooShort(duration) => {
-                write!(f, "duration is below 1 (second): {}", duration)
+                write!(f, "duration is below 1 (second): {duration}")
             }
             Self::DurationTooLong(duration) => {
-                write!(f, "duration is above 28,800 (seconds): {}", duration)
+                write!(f, "duration is above 28,800 (seconds): {duration}")
             }
             Self::RatingTooLow(rating) => {
-                write!(f, "rating is below 0.0: {}", rating)
+                write!(f, "rating is below 0.0: {rating}")
             }
             Self::RatingTooHigh(rating) => {
-                write!(f, "rating is above 5.0: {}", rating)
+                write!(f, "rating is above 5.0: {rating}")
             }
             Self::UploaderNameTooLong(count) => {
-                write!(f, "uploader name is longer than 255 characters: {}", count)
+                write!(f, "uploader name is longer than 255 characters: {count}")
             }
             Self::TooManyTags(count) => {
-                write!(f, "must not have more than 32 tags: {}", count)
+                write!(f, "must not have more than 32 tags: {count}")
             }
         }
     }

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -315,7 +315,7 @@ fn test_constructor_uploader_name_too_long() {
 fn test_constructor_too_many_tags() {
     let mut tags: Vec<String> = vec![];
     for i in 0..33 {
-        tags.push(format!("tag_{}", i));
+        tags.push(format!("tag_{i}"));
     }
 
     let video_result: Result<Video, VideoError> = Video::new(

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -37,14 +37,20 @@ fn test_constructor_all_fields() {
         String::from("http://www.example.com/videoplayer.php?video=123"),
         Some(600),
         Some(DateTime::from_utc(
-            NaiveDate::from_ymd(2021, 11, 5).and_hms(11, 20, 30),
-            FixedOffset::east(8 * 3600),
+            NaiveDate::from_ymd_opt(2021, 11, 5)
+                .unwrap()
+                .and_hms_opt(11, 20, 30)
+                .unwrap(),
+            FixedOffset::east_opt(8 * 3600).unwrap(),
         )),
         Some(4.2),
         Some(12345),
         Some(DateTime::from_utc(
-            NaiveDate::from_ymd(2007, 11, 5).and_hms(11, 20, 30),
-            FixedOffset::east(8 * 3600),
+            NaiveDate::from_ymd_opt(2007, 11, 5)
+                .unwrap()
+                .and_hms_opt(11, 20, 30)
+                .unwrap(),
+            FixedOffset::east_opt(8 * 3600).unwrap(),
         )),
         Some(true),
         Some(Restriction::new(

--- a/tests/video_builder.rs
+++ b/tests/video_builder.rs
@@ -28,14 +28,20 @@ fn test_all_fields() {
     )
     .duration(600)
     .expiration_date(DateTime::from_utc(
-        NaiveDate::from_ymd(2021, 11, 5).and_hms(11, 20, 30),
-        FixedOffset::east(8 * 3600),
+        NaiveDate::from_ymd_opt(2021, 11, 5)
+            .unwrap()
+            .and_hms_opt(11, 20, 30)
+            .unwrap(),
+        FixedOffset::east_opt(8 * 3600).unwrap(),
     ))
     .rating(4.2)
     .view_count(12345)
     .publication_date(DateTime::from_utc(
-        NaiveDate::from_ymd(2007, 11, 5).and_hms(11, 20, 30),
-        FixedOffset::east(8 * 3600),
+        NaiveDate::from_ymd_opt(2007, 11, 5)
+            .unwrap()
+            .and_hms_opt(11, 20, 30)
+            .unwrap(),
+        FixedOffset::east_opt(8 * 3600).unwrap(),
     ))
     .family_friendly(true)
     .restriction(Restriction::new(


### PR DESCRIPTION
I have fixed minor imperfections. These are typos, deprecated function calls and the use of variables in format strings.
The latter was displayed as a warning in the current stable Rust release 1.70.