### PR TITLE
Integration Tests and handling for alternates and canonical

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ exclude = [
 [dependencies]
 xml-builder = "0.5.1"
 chrono = "0.4.22"
+
+[dev-dependencies]
+pretty_assertions = "1.3.0"

--- a/examples/generate_url_sitemap_with_alternates.rs
+++ b/examples/generate_url_sitemap_with_alternates.rs
@@ -1,0 +1,52 @@
+use chrono::{DateTime, FixedOffset, NaiveDate};
+use sitemap_rs::url::{Alternate, ChangeFrequency, Url};
+use sitemap_rs::url_set::UrlSet;
+
+fn main() {
+    /*
+     * There are two functions you can use to add alternates. The first one is
+     * alternates() which expects a Vector with Alternate objects in it.
+     * alternates() overwrites existing values in the alternates-attribute
+     * of Url. The second one is push_alternate() which expects 2 &str, hreflang
+     * and href. push_alternate() appends to the alternates-attribute instead of
+     * overwriting.
+     * In the following example both are used.
+     */
+    let urls: Vec<Url> = vec![Url::builder(String::from("https://www.example.com/"))
+        .last_modified(DateTime::from_utc(
+            NaiveDate::from_ymd_opt(2005, 1, 1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+            FixedOffset::east_opt(0).unwrap(),
+        ))
+        .change_frequency(ChangeFrequency::Monthly)
+        .priority(0.8)
+        .alternates(vec![Alternate {
+            hreflang: String::from("en-US"),
+            href: String::from("https://www.example.com/"),
+        }])
+        .push_alternate(
+            String::from("de-DE"),
+            String::from("https://de.example.com/"),
+        )
+        .push_alternate(
+            String::from("de-CH"),
+            String::from("https://ch.example.com/de"),
+        )
+        .push_alternate(
+            String::from("fr-CH"),
+            String::from("https://ch.example.com/de"),
+        )
+        .push_alternate(String::from("it"), String::from("https://it.example.com/"))
+        .push_alternate(
+            String::from("x-default"),
+            String::from("https://www.example.com/country-selector"),
+        )
+        .build()
+        .expect("failed a <url> validation")];
+
+    let url_set: UrlSet = UrlSet::new(urls).expect("failed a <urlset> validation");
+    let mut buf = Vec::<u8>::new();
+    url_set.write(&mut buf).unwrap();
+}

--- a/src/image.rs
+++ b/src/image.rs
@@ -32,3 +32,26 @@ impl Image {
         Ok(image)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_to_xml() {
+        let image: Image = Image::new(String::from("https://www.example.com/image.jpg"));
+
+        let xml: XMLElement = image.to_xml().unwrap();
+        let mut buf = Vec::<u8>::new();
+        xml.render(&mut buf, true, true).unwrap();
+        let result = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            "\
+            <image:image>\n\
+                \t<image:loc>https://www.example.com/image.jpg</image:loc>\n\
+            </image:image>\n",
+            result
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub const NAMESPACE: &str = "http://www.sitemaps.org/schemas/sitemap/0.9";
 pub const IMAGE_NAMESPACE: &str = "http://www.google.com/schemas/sitemap-image/1.1";
 pub const VIDEO_NAMESPACE: &str = "http://www.google.com/schemas/sitemap-video/1.1";
 pub const NEWS_NAMESPACE: &str = "http://www.google.com/schemas/sitemap-news/0.9";
+pub const XHTML_NAMESPACE: &str = "http://www.w3.org/1999/xhtml";
 pub const ENCODING: &str = "UTF-8";
 pub const RFC_3339_SECONDS_FORMAT: SecondsFormat = SecondsFormat::Secs;
 pub const RFC_3339_USE_Z: bool = false;

--- a/src/news.rs
+++ b/src/news.rs
@@ -102,3 +102,52 @@ impl Publication {
         Ok(publication)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_news_to_xml() {
+        let news: News = News::new(
+            Publication::new(String::from("News Site"), String::from("en")),
+            DateTime::parse_from_rfc3339("2023-01-01T13:37:00+00:00").unwrap(),
+            String::from("Awesome Title of News Article"),
+        );
+        let xml: XMLElement = news.to_xml().unwrap();
+        let mut buf = Vec::<u8>::new();
+        xml.render(&mut buf, true, true).unwrap();
+        let result = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            "\
+            <news:news>\n\
+                \t<news:publication>\n\
+                    \t\t<news:name>News Site</news:name>\n\
+                    \t\t<news:language>en</news:language>\n\
+                \t</news:publication>\n\
+                \t<news:publication_date>2023-01-01T13:37:00+00:00</news:publication_date>\n\
+                \t<news:title>Awesome Title of News Article</news:title>\n\
+            </news:news>\n",
+            result
+        );
+    }
+
+    #[test]
+    fn test_publication_to_xml() {
+        let publication: Publication =
+            Publication::new(String::from("News Site"), String::from("en"));
+        let xml: XMLElement = publication.to_xml().unwrap();
+        let mut buf = Vec::<u8>::new();
+        xml.render(&mut buf, true, true).unwrap();
+        let result = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            "\
+            <news:publication>\n\
+                \t<news:name>News Site</news:name>\n\
+                \t<news:language>en</news:language>\n\
+            </news:publication>\n",
+            result
+        );
+    }
+}

--- a/src/sitemap.rs
+++ b/src/sitemap.rs
@@ -50,3 +50,30 @@ impl Sitemap {
         Ok(sitemap)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_to_xml() {
+        let sitemap: Sitemap = Sitemap::new(
+            String::from("https://www.example.com/sitemap1.xml.gz"),
+            Some(DateTime::parse_from_rfc3339("2023-01-01T13:37:00+00:00").unwrap()),
+        );
+
+        let xml: XMLElement = sitemap.to_xml().unwrap();
+        let mut buf = Vec::<u8>::new();
+        xml.render(&mut buf, true, true).unwrap();
+        let result = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            "\
+            <sitemap>\n\
+                \t<loc>https://www.example.com/sitemap1.xml.gz</loc>\n\
+                \t<lastmod>2023-01-01T13:37:00+00:00</lastmod>\n\
+            </sitemap>\n",
+            result
+        );
+    }
+}

--- a/src/url_error.rs
+++ b/src/url_error.rs
@@ -12,6 +12,9 @@ pub enum UrlError {
 
     /// Returned when a sitemap URL entry's `images` is more than 1,000.
     TooManyImages(usize),
+
+    /// Returned when a sitemap URL entry's alternates contain duplicate hreflang values.
+    DuplicateAlternateHreflangs(String, String),
 }
 
 impl error::Error for UrlError {}
@@ -27,6 +30,9 @@ impl Display for UrlError {
             }
             Self::TooManyImages(count) => {
                 write!(f, "must not contain more tha 1,000 images: {count}")
+            }
+            Self::DuplicateAlternateHreflangs(hreflang, href) => {
+                write!(f, "alternates must not contain duplicate hreflang values - hreflang: {hreflang}, href: {href}")
             }
         }
     }

--- a/src/video.rs
+++ b/src/video.rs
@@ -514,3 +514,139 @@ impl Uploader {
         Ok(uploader)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_uploader_to_xml() {
+        let uploader: Uploader = Uploader::new(
+            String::from("UserName"),
+            Some(String::from("https://www.example.com/users/UserName")),
+        );
+
+        let xml: XMLElement = uploader.to_xml().unwrap();
+        let mut buf = Vec::<u8>::new();
+        xml.render(&mut buf, true, true).unwrap();
+        let result = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            "\
+            <video:uploader info=\"https://www.example.com/users/UserName\">\
+                UserName\
+            </video:uploader>\n",
+            result
+        );
+    }
+
+    #[test]
+    fn test_platform_to_xml() {
+        let platform: Platform = Platform::new(
+            HashSet::from([PlatformType::Web, PlatformType::Tv]),
+            Relationship::Allow,
+        );
+
+        let xml: XMLElement = platform.to_xml().unwrap();
+        let mut buf = Vec::<u8>::new();
+        xml.render(&mut buf, true, true).unwrap();
+        let result = String::from_utf8(buf).unwrap();
+        // XXX: Values in the final result are random and not sorted. Probably
+        // because `Platform` is built from a HashSet and therefore has no order.
+        // It is weird though that `XMLElement.render(&mut buf, true, true)` does not
+        // sort the values as the second parameter is `should_sort`.
+        assert!(result.contains("<video:platform relationship=\"allow\">"));
+        assert!(result.contains("web tv") || result.contains("tv web"));
+        assert!(result.contains("</video:platform>"));
+    }
+
+    #[test]
+    fn test_restriction_to_xml() {
+        let restriction: Restriction = Restriction::new(
+            HashSet::from([String::from("IE"), String::from("GB")]),
+            Relationship::Allow,
+        );
+
+        let xml: XMLElement = restriction.to_xml().unwrap();
+        let mut buf = Vec::<u8>::new();
+        xml.render(&mut buf, true, true).unwrap();
+        let result = String::from_utf8(buf).unwrap();
+        // XXX: Values in the final result are random and not sorted. Probably
+        // because `Restriction` is built from a HashSet and therefore has no order.
+        // It is weird though that `XMLElement.render(&mut buf, true, true)` does not
+        // sort the values as the second parameter is `should_sort`.
+        assert!(result.contains("<video:restriction relationship=\"allow\">"));
+        assert!(result.contains("IE GB") || result.contains("GB IE"));
+        assert!(result.contains("</video:restriction>"));
+    }
+
+    #[test]
+    fn test_video_to_xml() {
+        let video: Video = Video::builder(
+            String::from("https://www.example.com/thumbnail.jpg"),
+            String::from("Video Title"),
+            String::from("Video description"),
+            String::from("https://www.example.com/content_location.mp4"),
+            String::from("https://www.example.com/player_location.php"),
+        )
+        .duration(600)
+        .expiration_date(DateTime::parse_from_rfc3339("2025-01-01T13:37:00+00:00").unwrap())
+        .rating(4.2)
+        .view_count(12345)
+        .publication_date(DateTime::parse_from_rfc3339("2009-01-01T13:37:00+00:00").unwrap())
+        .family_friendly(true)
+        /*
+        XXX: Add restriction and platform in test. Those are built from HashSets
+        and therefore have no order, which makes assertions on equality difficult.
+        It is weird that `XMLElement.render(&mut buf, true, true)` does not sort them
+        as the second parameter is `should_sort`.
+        .restriction(Restriction::new(
+            HashSet::from([String::from("IE"), String::from("GB")]),
+            Relationship::Allow,
+        ))
+        .platform(Platform::new(
+            HashSet::from([PlatformType::Web, PlatformType::Tv]),
+            Relationship::Allow,
+        ))
+        */
+        .requires_subscription(true)
+        .uploader(Uploader::new(
+            String::from("UserName"),
+            Some(String::from("https://www.example.com/users/UserName")),
+        ))
+        .live(false)
+        .tags(vec![
+            String::from("video tag 1"),
+            String::from("video tag 2"),
+        ])
+        .build()
+        .expect("failed a <video:video> validation");
+
+        let xml: XMLElement = video.to_xml().unwrap();
+        let mut buf = Vec::<u8>::new();
+        xml.render(&mut buf, true, true).unwrap();
+        let result = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            "\
+            <video:video>\n\
+                \t<video:thumbnail_loc>https://www.example.com/thumbnail.jpg</video:thumbnail_loc>\n\
+                \t<video:title>Video Title</video:title>\n\
+                \t<video:description>Video description</video:description>\n\
+                \t<video:content_loc>https://www.example.com/content_location.mp4</video:content_loc>\n\
+                \t<video:player_loc>https://www.example.com/player_location.php</video:player_loc>\n\
+                \t<video:duration>600</video:duration>\n\
+                \t<video:expiration_date>2025-01-01T13:37:00+00:00</video:expiration_date>\n\
+                \t<video:rating>4.2</video:rating>\n\
+                \t<video:view_count>12345</video:view_count>\n\
+                \t<video:publication_date>2009-01-01T13:37:00+00:00</video:publication_date>\n\
+                \t<video:family_friendly>yes</video:family_friendly>\n\
+                \t<video:requires_subscription>yes</video:requires_subscription>\n\
+                \t<video:uploader info=\"https://www.example.com/users/UserName\">UserName</video:uploader>\n\
+                \t<video:live>no</video:live>\n\
+                \t<video:tag>video tag 1</video:tag>\n\
+                \t<video:tag>video tag 2</video:tag>\n\
+            </video:video>\n",
+            result
+        );
+    }
+}

--- a/tests/image_sitemap_generation.rs
+++ b/tests/image_sitemap_generation.rs
@@ -1,0 +1,50 @@
+use pretty_assertions::assert_eq;
+use sitemap_rs::image::Image;
+use sitemap_rs::url::Url;
+use sitemap_rs::url_set::UrlSet;
+
+#[test]
+fn test_image_sitemap_generation() {
+    let urls: Vec<Url> = vec![
+        Url::builder(String::from("https://www.example.com/"))
+            .images(vec![
+                Image::new(String::from("https://www.example.com/image.jpg")),
+                Image::new(String::from("https://www.example.com/photo.jpg")),
+            ])
+            .build()
+            .expect("failed a <url> validation"),
+        Url::builder(String::from("https://www.example.com/page"))
+            .images(vec![Image::new(String::from(
+                "https://www.example.com/page-banner.jpg",
+            ))])
+            .build()
+            .expect("failed a <url> validation"),
+    ];
+
+    let url_set: UrlSet = UrlSet::new(urls).expect("failed a <urlset> validation");
+    let mut buf = Vec::<u8>::new();
+    url_set.write(&mut buf).unwrap();
+    let result = String::from_utf8(buf).unwrap();
+    assert_eq!(
+        "\
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:image=\"http://www.google.com/schemas/sitemap-image/1.1\">\n\
+            \t<url>\n\
+                \t\t<loc>https://www.example.com/</loc>\n\
+                \t\t<image:image>\n\
+                    \t\t\t<image:loc>https://www.example.com/image.jpg</image:loc>\n\
+                \t\t</image:image>\n\
+                \t\t<image:image>\n\
+                    \t\t\t<image:loc>https://www.example.com/photo.jpg</image:loc>\n\
+                \t\t</image:image>\n\
+            \t</url>\n\
+            \t<url>\n\
+                \t\t<loc>https://www.example.com/page</loc>\n\
+                \t\t<image:image>\n\
+                    \t\t\t<image:loc>https://www.example.com/page-banner.jpg</image:loc>\n\
+                \t\t</image:image>\n\
+            \t</url>\n\
+        </urlset>\n",
+        result
+    );
+}

--- a/tests/index_sitemap_generation.rs
+++ b/tests/index_sitemap_generation.rs
@@ -1,0 +1,39 @@
+use chrono::DateTime;
+use pretty_assertions::assert_eq;
+use sitemap_rs::sitemap::Sitemap;
+use sitemap_rs::sitemap_index::SitemapIndex;
+
+#[test]
+fn test_index_sitemap_generation() {
+    let sitemaps: Vec<Sitemap> = vec![
+        Sitemap::new(
+            String::from("https://www.example.com/sitemap1.xml.gz"),
+            Some(DateTime::parse_from_rfc3339("2023-01-01T13:37:00+00:00").unwrap()),
+        ),
+        Sitemap::new(
+            String::from("https://www.example.com/sitemap2.xml.gz"),
+            Some(DateTime::parse_from_rfc3339("2023-03-03T08:15:00+00:00").unwrap()),
+        ),
+    ];
+
+    let index_sitemap: SitemapIndex =
+        SitemapIndex::new(sitemaps).expect("failed a <sitemapindex> validation");
+    let mut buf = Vec::<u8>::new();
+    index_sitemap.write(&mut buf).unwrap();
+    let result = String::from_utf8(buf).unwrap();
+    assert_eq!(
+        "\
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n\
+            \t<sitemap>\n\
+                \t\t<loc>https://www.example.com/sitemap1.xml.gz</loc>\n\
+                \t\t<lastmod>2023-01-01T13:37:00+00:00</lastmod>\n\
+            \t</sitemap>\n\
+            \t<sitemap>\n\
+                \t\t<loc>https://www.example.com/sitemap2.xml.gz</loc>\n\
+                \t\t<lastmod>2023-03-03T08:15:00+00:00</lastmod>\n\
+            \t</sitemap>\n\
+        </sitemapindex>\n",
+        result
+    );
+}

--- a/tests/news_sitemap_generation.rs
+++ b/tests/news_sitemap_generation.rs
@@ -1,0 +1,40 @@
+use chrono::DateTime;
+use pretty_assertions::assert_eq;
+use sitemap_rs::news::{News, Publication};
+use sitemap_rs::url::Url;
+use sitemap_rs::url_set::UrlSet;
+
+#[test]
+fn test_news_sitemap_generation() {
+    let urls: Vec<Url> = vec![Url::builder(String::from("https://www.example.com/"))
+        .news(News::new(
+            Publication::new(String::from("News Site"), String::from("en")),
+            DateTime::parse_from_rfc3339("2023-01-01T13:37:00+00:00").unwrap(),
+            String::from("Awesome Title of News Article"),
+        ))
+        .build()
+        .expect("failed a <url> validation")];
+
+    let url_set: UrlSet = UrlSet::new(urls).expect("failed a <urlset> validation");
+    let mut buf = Vec::<u8>::new();
+    url_set.write(&mut buf).unwrap();
+    let result = String::from_utf8(buf).unwrap();
+    assert_eq!(
+        "\
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:news=\"http://www.google.com/schemas/sitemap-news/0.9\">\n\
+            \t<url>\n\
+                \t\t<loc>https://www.example.com/</loc>\n\
+                \t\t<news:news>\n\
+                    \t\t\t<news:publication>\n\
+                        \t\t\t\t<news:name>News Site</news:name>\n\
+                        \t\t\t\t<news:language>en</news:language>\n\
+                    \t\t\t</news:publication>\n\
+                    \t\t\t<news:publication_date>2023-01-01T13:37:00+00:00</news:publication_date>\n\
+                    \t\t\t<news:title>Awesome Title of News Article</news:title>\n\
+                \t\t</news:news>\n\
+            \t</url>\n\
+        </urlset>\n",
+        result
+    );
+}

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -2,13 +2,15 @@ extern crate core;
 
 use chrono::{DateTime, Utc};
 use sitemap_rs::image::Image;
-use sitemap_rs::url::{ChangeFrequency, Url, DEFAULT_PRIORITY};
+use sitemap_rs::url::{Alternate, ChangeFrequency, Url, DEFAULT_PRIORITY};
 use sitemap_rs::url_error::UrlError;
 
 #[test]
 fn test_constructor_only_required_fields() {
     let url_result: Result<Url, UrlError> = Url::new(
         String::from("https://www.toddgriffin.me/"),
+        None,
+        None,
         None,
         None,
         None,
@@ -29,6 +31,8 @@ fn test_constructor_all_normal_fields() {
         None,
         None,
         None,
+        None,
+        None,
     );
     assert!(url_result.is_ok());
 }
@@ -43,6 +47,8 @@ fn test_constructor_priority_too_low() {
         None,
         None,
         None,
+        None,
+        None,
     );
     match url_result {
         Ok(_) => panic!("Returned a URL!"),
@@ -53,6 +59,9 @@ fn test_constructor_priority_too_low() {
             }
             UrlError::PriorityTooHigh(_) => panic!("Returned PriorityTooHigh!"),
             UrlError::TooManyImages(_) => panic!("Returned TooManyImages!"),
+            UrlError::DuplicateAlternateHreflangs(..) => {
+                panic!("Returned DuplicateAlternateHreflangs!");
+            }
         },
     }
 }
@@ -67,6 +76,8 @@ fn test_constructor_priority_too_high() {
         None,
         None,
         None,
+        None,
+        None,
     );
     match url_result {
         Ok(_) => panic!("Returned a URL!"),
@@ -77,6 +88,9 @@ fn test_constructor_priority_too_high() {
                 assert!((priority - expected_priority).abs() < f32::EPSILON);
             }
             UrlError::TooManyImages(_) => panic!("Returned TooManyImages!"),
+            UrlError::DuplicateAlternateHreflangs(..) => {
+                panic!("Returned DuplicateAlternateHreflangs!");
+            }
         },
     }
 }
@@ -100,6 +114,8 @@ fn test_constructor_too_many_images() {
         Some(images),
         None,
         None,
+        None,
+        None,
     );
     match url_result {
         Ok(_) => panic!("Returned a URL!"),
@@ -107,6 +123,47 @@ fn test_constructor_too_many_images() {
             UrlError::PriorityTooLow(_) => panic!("Returned PriorityTooLow!"),
             UrlError::PriorityTooHigh(_) => panic!("Returned PriorityTooHigh!"),
             UrlError::TooManyImages(count) => assert_eq!(1001, count),
+            UrlError::DuplicateAlternateHreflangs(..) => {
+                panic!("Returned DuplicateAlternateHreflangs!");
+            }
+        },
+    }
+}
+
+#[test]
+fn test_constructor_duplicate_alternate_hreflangs() {
+    let alternates: Vec<Alternate> = vec![
+        Alternate {
+            hreflang: String::from("en-US"),
+            href: String::from("https://www.example.com/"),
+        },
+        Alternate {
+            hreflang: String::from("en-US"),
+            href: String::from("https://www.example.com/"),
+        },
+    ];
+
+    let url_result: Result<Url, UrlError> = Url::new(
+        String::from("https://www.example.com/"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(alternates),
+        None,
+    );
+    match url_result {
+        Ok(_) => panic!("Returned a URL!"),
+        Err(e) => match e {
+            UrlError::PriorityTooLow(_) => panic!("Returned PriorityTooLow!"),
+            UrlError::PriorityTooHigh(_) => panic!("Returned PriorityTooHigh!"),
+            UrlError::TooManyImages(_) => panic!("Returned TooManyImages!"),
+            UrlError::DuplicateAlternateHreflangs(hreflang, href) => {
+                assert_eq!(String::from("en-US"), hreflang);
+                assert_eq!(String::from("https://www.example.com/"), href);
+            }
         },
     }
 }

--- a/tests/url_builder.rs
+++ b/tests/url_builder.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use sitemap_rs::image::Image;
 use sitemap_rs::news::{News, Publication};
-use sitemap_rs::url::{ChangeFrequency, Url, DEFAULT_PRIORITY};
+use sitemap_rs::url::{Alternate, ChangeFrequency, Url, DEFAULT_PRIORITY};
 use sitemap_rs::url_builder::UrlBuilder;
 use sitemap_rs::url_error::UrlError;
 use sitemap_rs::video::Video;
@@ -46,6 +46,8 @@ fn test_all_fields() {
                     "Local Software Engineer, Todd, Finally Completes Project He Has Talked About For Years",
                 ),
             ))
+            .alternates(vec![Alternate { hreflang: String::from("en-US"), href: String::from("https://www.example.com/")}])
+            .push_alternate(String::from("de-DE"), String::from("https://de.example.com/"))
             .build();
     assert!(url_builder_result.is_ok());
 }

--- a/tests/url_sitemap_generation.rs
+++ b/tests/url_sitemap_generation.rs
@@ -1,0 +1,186 @@
+use chrono::DateTime;
+use pretty_assertions::assert_eq;
+use sitemap_rs::url::{Alternate, ChangeFrequency, Url, DEFAULT_PRIORITY};
+use sitemap_rs::url_set::UrlSet;
+
+#[test]
+fn test_sitemap_generation_location() {
+    let urls: Vec<Url> = vec![Url::builder(String::from("https://www.example.com/"))
+        .build()
+        .expect("failed a <url> validation")];
+
+    let url_set: UrlSet = UrlSet::new(urls).expect("failed a <urlset> validation");
+    let mut buf = Vec::<u8>::new();
+    url_set.write(&mut buf).unwrap();
+    let result = String::from_utf8(buf).unwrap();
+    assert_eq!(
+        "\
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n\
+            \t<url>\n\
+                \t\t<loc>https://www.example.com/</loc>\n\
+            \t</url>\n\
+        </urlset>\n",
+        result
+    );
+}
+
+#[test]
+fn test_sitemap_generation_last_modified() {
+    let urls: Vec<Url> = vec![Url::builder(String::from("https://www.example.com/"))
+        .last_modified(DateTime::parse_from_rfc3339("2023-01-01T13:37:00+00:00").unwrap())
+        .build()
+        .expect("failed a <url> validation")];
+
+    let url_set: UrlSet = UrlSet::new(urls).expect("failed a <urlset> validation");
+    let mut buf = Vec::<u8>::new();
+    url_set.write(&mut buf).unwrap();
+    let result = String::from_utf8(buf).unwrap();
+    assert_eq!(
+        "\
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n\
+            \t<url>\n\
+                \t\t<loc>https://www.example.com/</loc>\n\
+                \t\t<lastmod>2023-01-01T13:37:00+00:00</lastmod>\n\
+            \t</url>\n\
+        </urlset>\n",
+        result
+    );
+}
+
+#[test]
+fn test_sitemap_generation_change_frequency() {
+    let urls: Vec<Url> = vec![Url::builder(String::from("https://www.example.com/"))
+        .change_frequency(ChangeFrequency::Weekly)
+        .build()
+        .expect("failed a <url> validation")];
+
+    let url_set: UrlSet = UrlSet::new(urls).expect("failed a <urlset> validation");
+    let mut buf = Vec::<u8>::new();
+    url_set.write(&mut buf).unwrap();
+    let result = String::from_utf8(buf).unwrap();
+    assert_eq!(
+        "\
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n\
+            \t<url>\n\
+                \t\t<loc>https://www.example.com/</loc>\n\
+                \t\t<changefreq>weekly</changefreq>\n\
+            \t</url>\n\
+        </urlset>\n",
+        result
+    );
+}
+
+#[test]
+fn test_sitemap_generation_priority() {
+    let urls: Vec<Url> = vec![Url::builder(String::from("https://www.example.com/"))
+        .priority(DEFAULT_PRIORITY)
+        .build()
+        .expect("failed a <url> validation")];
+
+    let url_set: UrlSet = UrlSet::new(urls).expect("failed a <urlset> validation");
+    let mut buf = Vec::<u8>::new();
+    url_set.write(&mut buf).unwrap();
+    let result = String::from_utf8(buf).unwrap();
+    assert_eq!(
+        "\
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n\
+            \t<url>\n\
+                \t\t<loc>https://www.example.com/</loc>\n\
+                \t\t<priority>0.5</priority>\n\
+            \t</url>\n\
+        </urlset>\n",
+        result
+    );
+}
+
+#[test]
+fn test_sitemap_generation_alternates() {
+    let urls: Vec<Url> = vec![Url::builder(String::from("https://www.example.com/"))
+        .alternates(vec![
+            Alternate {
+                hreflang: String::from("en-US"),
+                href: String::from("https://www.example.com/"),
+            },
+            Alternate {
+                hreflang: String::from("de-DE"),
+                href: String::from("https://de.example.com/"),
+            },
+        ])
+        .push_alternate(
+            String::from("x-default"),
+            String::from("https://www.example.com/country-selector"),
+        )
+        .push_alternate(String::from("it"), String::from("https://it.example.com/"))
+        .build()
+        .expect("failed a <url> validation")];
+
+    let url_set: UrlSet = UrlSet::new(urls).expect("failed a <urlset> validation");
+    let mut buf = Vec::<u8>::new();
+    url_set.write(&mut buf).unwrap();
+    let result = String::from_utf8(buf).unwrap();
+    assert_eq!(
+        "\
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:xhtml=\"http://www.w3.org/1999/xhtml\">\n\
+            \t<url>\n\
+                \t\t<loc>https://www.example.com/</loc>\n\
+                \t\t<xhtml:link rel=\"alternate\" hreflang=\"en-US\" href=\"https://www.example.com/\" />\n\
+                \t\t<xhtml:link rel=\"alternate\" hreflang=\"de-DE\" href=\"https://de.example.com/\" />\n\
+                \t\t<xhtml:link rel=\"alternate\" hreflang=\"x-default\" href=\"https://www.example.com/country-selector\" />\n\
+                \t\t<xhtml:link rel=\"alternate\" hreflang=\"it\" href=\"https://it.example.com/\" />\n\
+            \t</url>\n\
+        </urlset>\n",
+        result
+    );
+}
+
+#[test]
+fn test_sitemap_generation_all() {
+    let urls: Vec<Url> = vec![Url::builder(String::from("https://www.example.com/"))
+        .last_modified(DateTime::parse_from_rfc3339("2023-01-01T13:37:00+00:00").unwrap())
+        .change_frequency(ChangeFrequency::Weekly)
+        .priority(DEFAULT_PRIORITY)
+        .alternates(vec![
+            Alternate {
+                hreflang: String::from("en-US"),
+                href: String::from("https://www.example.com/"),
+            },
+            Alternate {
+                hreflang: String::from("de-DE"),
+                href: String::from("https://de.example.com/"),
+            },
+        ])
+        .push_alternate(
+            String::from("x-default"),
+            String::from("https://www.example.com/country-selector"),
+        )
+        .push_alternate(String::from("it"), String::from("https://it.example.com/"))
+        .build()
+        .expect("failed a <url> validation")];
+
+    let url_set: UrlSet = UrlSet::new(urls).expect("failed a <urlset> validation");
+    let mut buf = Vec::<u8>::new();
+    url_set.write(&mut buf).unwrap();
+    let result = String::from_utf8(buf).unwrap();
+    assert_eq!(
+        "\
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:xhtml=\"http://www.w3.org/1999/xhtml\">\n\
+            \t<url>\n\
+                \t\t<loc>https://www.example.com/</loc>\n\
+                \t\t<lastmod>2023-01-01T13:37:00+00:00</lastmod>\n\
+                \t\t<changefreq>weekly</changefreq>\n\
+                \t\t<priority>0.5</priority>\n\
+                \t\t<xhtml:link rel=\"alternate\" hreflang=\"en-US\" href=\"https://www.example.com/\" />\n\
+                \t\t<xhtml:link rel=\"alternate\" hreflang=\"de-DE\" href=\"https://de.example.com/\" />\n\
+                \t\t<xhtml:link rel=\"alternate\" hreflang=\"x-default\" href=\"https://www.example.com/country-selector\" />\n\
+                \t\t<xhtml:link rel=\"alternate\" hreflang=\"it\" href=\"https://it.example.com/\" />\n\
+            \t</url>\n\
+        </urlset>\n",
+        result
+    );
+}

--- a/tests/video_sitemap_generation.rs
+++ b/tests/video_sitemap_generation.rs
@@ -1,0 +1,91 @@
+use chrono::DateTime;
+use pretty_assertions::assert_eq;
+use sitemap_rs::url::Url;
+use sitemap_rs::url_set::UrlSet;
+use sitemap_rs::video::{Uploader, Video};
+
+#[test]
+fn test_video_sitemap_generation() {
+    let video: Video = Video::builder(
+        String::from("https://www.example.com/thumbnail.jpg"),
+        String::from("Video Title"),
+        String::from("Video description"),
+        String::from("https://www.example.com/content_location.mp4"),
+        String::from("https://www.example.com/player_location.php"),
+    )
+    .duration(600)
+    .expiration_date(DateTime::parse_from_rfc3339("2025-01-01T13:37:00+00:00").unwrap())
+    .rating(4.2)
+    .view_count(12345)
+    .publication_date(DateTime::parse_from_rfc3339("2009-01-01T13:37:00+00:00").unwrap())
+    .family_friendly(true)
+    /*
+    XXX: Add restriction and platform in test. Those are built from HashSets
+    and therefore have no order, which makes assertions on equality difficult.
+        .restriction(Restriction::new(
+            HashSet::from([
+                String::from("IE"),
+                String::from("GB"),
+                String::from("US"),
+                String::from("CA"),
+            ]),
+            Relationship::Allow,
+        ))
+        .platform(Platform::new(
+            HashSet::from([PlatformType::Web, PlatformType::Tv]),
+            Relationship::Allow,
+        ))
+     */
+    .requires_subscription(true)
+    .uploader(Uploader::new(
+        String::from("UserName"),
+        Some(String::from("https://www.example.com/users/UserName")),
+    ))
+    .live(false)
+    .tags(vec![
+        String::from("video tag 1"),
+        String::from("video tag 2"),
+    ])
+    .build()
+    .expect("failed a <video:video> validation");
+
+    let urls: Vec<Url> = vec![Url::builder(String::from(
+        "https://www.example.com/videos/some_video_landing_page.html",
+    ))
+    .videos(vec![video])
+    .build()
+    .expect("failed a <url> validation")];
+
+    let url_set: UrlSet = UrlSet::new(urls).expect("failed a <urlset> validation");
+    let mut buf = Vec::<u8>::new();
+    url_set.write(&mut buf).unwrap();
+    let result = String::from_utf8(buf).unwrap();
+    assert_eq!(
+        "\
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:video=\"http://www.google.com/schemas/sitemap-video/1.1\">\n\
+            \t<url>\n\
+                \t\t<loc>https://www.example.com/videos/some_video_landing_page.html</loc>\n\
+                \t\t<video:video>\n\
+                    \t\t\t<video:thumbnail_loc>https://www.example.com/thumbnail.jpg</video:thumbnail_loc>\n\
+                    \t\t\t<video:title>Video Title</video:title>\n\
+                    \t\t\t<video:description>Video description</video:description>\n\
+                    \t\t\t<video:content_loc>https://www.example.com/content_location.mp4</video:content_loc>\n\
+                    \t\t\t<video:player_loc>https://www.example.com/player_location.php</video:player_loc>\n\
+                    \t\t\t<video:duration>600</video:duration>\n\
+                    \t\t\t<video:expiration_date>2025-01-01T13:37:00+00:00</video:expiration_date>\n\
+                    \t\t\t<video:rating>4.2</video:rating>\n\
+                    \t\t\t<video:view_count>12345</video:view_count>\n\
+                    \t\t\t<video:publication_date>2009-01-01T13:37:00+00:00</video:publication_date>\n\
+                    \t\t\t<video:family_friendly>yes</video:family_friendly>\n\
+                    \t\t\t<video:requires_subscription>yes</video:requires_subscription>\n\
+                    \t\t\t<video:uploader info=\"https://www.example.com/users/UserName\">UserName</video:uploader>\n\
+                    \t\t\t<video:live>no</video:live>\n\
+                    \t\t\t<video:tag>video tag 1</video:tag>\n\
+                    \t\t\t<video:tag>video tag 2</video:tag>\n\
+                \t\t</video:video>\n\
+            \t</url>\n\
+        </urlset>\n",
+        result
+    );
+}


### PR DESCRIPTION
I have added the ability to specify language alternates and the canonical URL, so that they can be included in the sitemap.
I have also added integration tests for generating the sitemaps.

Please review the changes made and notify me if anything doesn't fit correctly. I'll be happy to make any necessary adjustments accordingly.